### PR TITLE
Fix fatal error ServiceNotFoundException

### DIFF
--- a/src/GrumPHPExtension.php
+++ b/src/GrumPHPExtension.php
@@ -14,7 +14,7 @@ class GrumPHPExtension implements ExtensionInterface
     public function load(ContainerBuilder $container)
     {
         /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher */
-        $event_dispatcher = $container->get('symfony\component\eventdispatcher\eventdispatcher');
+        $event_dispatcher = $container->get('Symfony\Component\EventDispatcher\EventDispatcher');
         $event_dispatcher->addSubscriber(new GrumphpEventSubscriber());
     }
 }


### PR DESCRIPTION
Fatal error: Uncaught Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "symfony\component\eventdispatcher\eventdispatcher". in /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/symfony/dependency-injection/ContainerBuilder.php on line 1033

Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "symfony\component\eventdispatcher\eventdispatcher". in /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/symfony/dependency-injection/ContainerBuilder.php on line 1033

Call Stack:
    0.0033     401152   1. {main}() /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/phpro/grumphp/bin/grumphp:0
    0.0036     401472   2. {closure:/Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/phpro/grumphp/bin/grumphp:8-51}() /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/phpro/grumphp/bin/grumphp:51
    0.0158    1665120   3. GrumPHP\Configuration\ContainerFactory::build() /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/phpro/grumphp/bin/grumphp:46
    0.0388    2410560   4. GrumPHP\Configuration\ContainerBuilder::buildFromConfiguration() /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/phpro/grumphp/src/Configuration/ContainerFactory.php:24
    0.1377    5142784   5. Symfony\Component\DependencyInjection\ContainerBuilder->compile() /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/phpro/grumphp/src/Configuration/ContainerBuilder.php:54
    0.1405    5149080   6. Symfony\Component\DependencyInjection\Compiler\Compiler->compile() /Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/symfony/dependency-injection/ContainerBuilder.php:762