### PR TITLE
Remove behat for extensions

### DIFF
--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -25,11 +25,8 @@ parameters:
         - yamllint
     tests:
       tasks:
-        - behat
         - phpunit
   tasks:
-    behat:
-      config: .behat-merged.yml
     composer: ~
     git_blacklist:
       keywords:


### PR DESCRIPTION
There's a bug in the default behat config:
```
default:
  gherkin:
    filters:
      tags: ~@javascript
  suites:
    default:
      paths:
        - %paths.base%/tests/features
      contexts:
        - Drupal\DrupalExtension\Context\ConfigContext
        - Drupal\DrupalExtension\Context\DrupalContext
        - Drupal\DrupalExtension\Context\MarkupContext
        - Drupal\DrupalExtension\Context\MessageContext
        - Drupal\DrupalExtension\Context\MinkContext
        - Gent\QA\Drupal\Behat\Context\AccessContext
        - Gent\QA\Drupal\Behat\Context\DebugContext:
            path: %paths.base%/tests/features/dumps
        - Gent\QA\Drupal\Behat\Context\UriContext
        - Gent\QA\Drupal\Behat\Context\SelectorContext

```

```
$ vendor/bin/grumphp run

GrumPHP is sniffing your code!/Volumes/webdev/www/digipolis/drupal_module_dg-auth/vendor/symfony/yaml/Inline.php:305:
string(27) "%paths.base%/tests/features"

In Inline.php line 306:
                                                                                                                           
  The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 8 (near "- %paths.base%/te  
  sts/features").           
```