### PR TITLE
Workaround downgrade to phpstan 0.12.42

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "phpmd/phpmd": "^2.9",
         "phpro/grumphp": "^0.18.1",
         "phpspec/prophecy": "^1.10",
+        "phpstan/phpstan": "0.12.42",
         "phpstan/phpstan-deprecation-rules": "^0.12.5",
         "phpunit/phpunit": "^7.5",
         "sebastian/phpcpd": "^4.0",


### PR DESCRIPTION
After the latest release of phpstan/phpstan 0.12.43 we run into reflection errors.
Issue has been reported on the mglaman/drupal-check project:
mglaman/drupal-check#186

Quick fix for a project using this would be to manually require the previous version for the time being:
composer require phpstan/phpstan:"0.12.42"