### PR TITLE
Add php compatibility checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,10 @@ plugins:
       standard: ".phpcs.xml"
 ```
 
+### PHP compatibility
 
+In order to check php compatibility you can use the phpcs `PHPCompatibility` sniff:
+
+```bash
+php vendor/bin/phpcs -p --ignore="*/vendor/*" --extensions=php,inc,module,install,theme --runtime-set testVersion 8.1 --standard=PHPCompatibility ./web/modules/contrib
+```

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "mglaman/phpstan-drupal": "^1.1",
         "nette/neon": "^3.2",
         "nielsdeblaauw/twigcs-a11y": "^0.3.0",
+        "phpcompatibility/php-compatibility": "^9.3",
         "phpmd/phpmd": "^2.11",
         "phpro/grumphp-shim": "^1.5.0",
         "phpspec/prophecy": "^1.10",

--- a/configs/phpcs.xml
+++ b/configs/phpcs.xml
@@ -8,6 +8,7 @@
 
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
+  <rule ref="./vendor/phpcompatibility/php-compatibility/PHPCompatibility"/>
 
   <!-- PSR-12 sniffs -->
   <rule ref="PSR12.Files.DeclareStatement"/>

--- a/configs/phpcs.xml
+++ b/configs/phpcs.xml
@@ -8,7 +8,6 @@
 
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
-  <rule ref="./vendor/phpcompatibility/php-compatibility/PHPCompatibility"/>
 
   <!-- PSR-12 sniffs -->
   <rule ref="PSR12.Files.DeclareStatement"/>


### PR DESCRIPTION
Needs a grumphp plugin to pass in the checks against a specific PHP version by adding `--runtime-set testVersion 8.1` to the command line command

See
- https://github.com/wunderio/grumphp-php-compatibility
- https://github.com/wunderio/code-quality/blob/master/src/Task/PhpCompatibility/PhpCompatibilityTask.php
