### PR TITLE
PHP-81: Add travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: php
+sudo: false
+
+php:
+  - 7.4
+  - 8.0
+  - 8.1
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+env:
+  matrix:
+    - DRUPAL=9.3
+    - DRUPAL=9.4
+
+jobs:
+  fast_finish: true
+
+before_install:
+  # Update composer.
+  - composer self-update --2
+  - composer --version
+
+  # Configure the authentication mechanisms.
+  - if [ "${GITHUB_TOKEN}" != "" ]; then composer config github-oauth.github.com ${GITHUB_TOKEN}; fi
+  - if [ "${REPMAN_TOKEN}" != "" ]; then composer config --global --auth http-basic.digipolis.repo.repman.io token ${REPMAN_TOKEN}; fi
+
+  # Require Drupal core.
+  - composer require -n --no-update --sort-packages --dev drupal/core:~$DRUPAL.0
+
+  # Get and run the Code Climate test reporter.
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+script:
+  - composer install -n
+
+after_script:
+  # Run the Code Climate test reporter.
+  - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
 
   # Configure the authentication mechanisms.
   - if [ "${GITHUB_TOKEN}" != "" ]; then composer config github-oauth.github.com ${GITHUB_TOKEN}; fi
-  - if [ "${REPMAN_TOKEN}" != "" ]; then composer config --global --auth http-basic.digipolis.repo.repman.io token ${REPMAN_TOKEN}; fi
 
   # Require Drupal core.
   - composer require -n --no-update --sort-packages --dev drupal/core:~$DRUPAL.0

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "drupal/coder": "^8.3",
-        "drupal/core": "^9.1",
+        "drupal/core": "^9.3",
         "drupal/drupal-extension": "^4.1",
         "enlightn/security-checker": "^1.4",
         "ergebnis/composer-normalize": "^2.11",

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,6 @@
             "role": "developer"
         }
     ],
-    "autoload": {
-        "psr-4": {
-            "Digipolisgent\\QA\\Drupal\\": "src/"
-        }
-    },
     "require": {
         "php": "^7.4 || ^8.0",
         "drupal/coder": "^8.3",
@@ -46,7 +41,17 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Digipolisgent\\QA\\Drupal\\": "src/"
+        }
+    },
     "config": {
+        "allow-plugins": {
+            "phpro/grumphp-shim": true,
+            "ergebnis/composer-normalize": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true
     }
 }


### PR DESCRIPTION
- Bumped minimal Drupal version to ^9.3.
- Add travis build to validate if it can be installed with all supported
  PHP and Drupal core versions.