### PR TITLE
Add excluding hand-crafted mocks from coverage reports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [Unreleased]
+
+### Added
+
+- Add excluding hand-crafted mocks from coverage reports. This will exclude
+  file names ending with Stub.php or Spy.php.
+
 ## [1.7.3]
 
 ### Added

--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -42,6 +42,8 @@
       <exclude>
         <directory>./vendor</directory>
         <directory suffix=".api.php">./</directory>
+        <directory suffix="Spy.php">./</directory>
+        <directory suffix="Stub.php">./</directory>
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
         <directory suffix="TestCase.php">./</directory>

--- a/configs/phpunit-site.xml
+++ b/configs/phpunit-site.xml
@@ -43,6 +43,8 @@
       <directory suffix=".php">web/themes/custom</directory>
       <exclude>
         <directory suffix=".api.php">./</directory>
+        <directory suffix="Spy.php">./</directory>
+        <directory suffix="Stub.php">./</directory>
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
         <directory suffix="TestCase.php">./</directory>


### PR DESCRIPTION
This excludes manually crafted mocks as long as their file name ends with:

- Spy.php
- Stub.php