### PR TITLE
Add exclude node modules from PHPUnit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [Unreleased]
+
+### added
+
+- Add exclude node modules from PHPUnit.
+
 ## [1.8.0]
 
 ### Added

--- a/configs/phpunit-site.xml
+++ b/configs/phpunit-site.xml
@@ -48,6 +48,7 @@
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
         <directory suffix="TestCase.php">./</directory>
+        <directory>web/themes/custom/*/source</directory>
       </exclude>
     </whitelist>
   </filter>


### PR DESCRIPTION
Some node modules have PHP in them ¯\_(ツ)_/¯.
We add the custom theme source directory (who only contains scss, js & node modules) to the excluded directories.

Example of node module with PHP: https://github.com/WebReflection/flatted/tree/main/php