### PR TITLE
BEHAT-UPDATE: Change to browserkit instead of goutte

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.1",
         "drupal/coder": "^8.3",
         "drupal/core": "^9.4 || ^10.0",
-        "drupal/drupal-extension": "^4.1 || ^5.0",
+        "drupal/drupal-extension": "^5.0",
         "enlightn/security-checker": "^1.4",
         "ergebnis/composer-normalize": "^2.11",
         "mglaman/phpstan-drupal": "^1.1",

--- a/configs/behat.yml
+++ b/configs/behat.yml
@@ -18,12 +18,12 @@ default:
         - Digipolisgent\QA\Drupal\Behat\Context\UriContext
         - Digipolisgent\QA\Drupal\Behat\Context\SelectorContext
   extensions:
-    Behat\MinkExtension:
-      goutte: ~
+    Drupal\MinkExtension:
+      browserkit_http: ~
       selenium2: ~
       sessions:
         default:
-          goutte: ~
+          browserkit_http: ~
         javascript:
           selenium2:
             wd_host: "http://localhost:4444/wd/hub"


### PR DESCRIPTION
Use the browserkit_http driver instead og the goutte driver. See: https://github.com/jhedstrom/drupalextension/commit/2ab66a7eae53ae4e1e5824edaa72e98039b084db