### PR TITLE
Add support for Drupal 10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [2.1.0]
+
+### Changes
+
+- Update the phpunit config file to make them work with the changes done to
+`core/tests/bootstrap.php` in Drupal 10.2.
+- Update the minimal Drupal version to 10.2.
+- Drop support for Drupal 9.
+
 ## [2.0.3]
 
 ### Changed
@@ -388,6 +397,8 @@ Initial setup of the qa-drupal package:
 - Default config files and checks for a Drupal site.
 - Default config files and checks for a Drupal module.
 
+[2.1.0]: https://github.com/district09/php_package_qa-drupal/compare/2.0.3...2.1.0
+[2.0.3]: https://github.com/district09/php_package_qa-drupal/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/district09/php_package_qa-drupal/compare/2.0.1...2.0.2
 [2.0.1]: https://github.com/district09/php_package_qa-drupal/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/district09/php_package_qa-drupal/compare/1.8.1...2.0.0

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.1",
         "drupal/coder": "^8.3",
-        "drupal/core": "^9.4 || ^10.0",
+        "drupal/core": "^10.2",
         "drupal/drupal-extension": "^5.0",
         "enlightn/security-checker": "^1.4",
         "ergebnis/composer-normalize": "^2.11",

--- a/configs/phpunit-site.xml
+++ b/configs/phpunit-site.xml
@@ -16,16 +16,16 @@
 
   <testsuites>
     <testsuite name="unit">
-      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/UnitTestSuite.php</file>
+      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/UnitTestSuite.php</file>
     </testsuite>
     <testsuite name="kernel">
-      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/KernelTestSuite.php</file>
+      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/KernelTestSuite.php</file>
     </testsuite>
     <testsuite name="functional">
-      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalTestSuite.php</file>
+      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalTestSuite.php</file>
     </testsuite>
     <testsuite name="functional-javascript">
-      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalJavascriptTestSuite.php</file>
+      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalJavascriptTestSuite.php</file>
     </testsuite>
   </testsuites>
 
@@ -38,9 +38,9 @@
 
   <coverage>
     <include>
-      <directory suffix=".php">web/modules/custom</directory>
-      <directory suffix=".php">web/profiles/custom</directory>
-      <directory suffix=".php">web/themes/custom</directory>
+      <directory suffix=".php">modules/custom</directory>
+      <directory suffix=".php">profiles/custom</directory>
+      <directory suffix=".php">themes/custom</directory>
     </include>
     <exclude>
         <directory suffix=".api.php">./</directory>
@@ -49,7 +49,7 @@
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
         <directory suffix="TestCase.php">./</directory>
-        <directory>web/themes/custom/*/source</directory>
+        <directory>themes/custom/*/source</directory>
     </exclude>
 
     <report>


### PR DESCRIPTION
This unfortunately means dropping support for previous Drupal versions. A line was added to Drupal's phpunit boostrap file, causing the old config to break:
https://git.drupalcode.org/project/drupal/-/blob/10.2.0/core/tests/bootstrap.php#L185