### PR TITLE
Add custom theme(s) node_modules to the phpcpd exclude patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [2.1.1]
+
+### Added
+
+- Add custom theme(s) node_modules to the phpcpd exclude patterns.
+
 ## [2.1.0]
 
 ### Changes
@@ -397,6 +403,7 @@ Initial setup of the qa-drupal package:
 - Default config files and checks for a Drupal site.
 - Default config files and checks for a Drupal module.
 
+[2.1.1]: https://github.com/district09/php_package_qa-drupal/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/district09/php_package_qa-drupal/compare/2.0.3...2.1.0
 [2.0.3]: https://github.com/district09/php_package_qa-drupal/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/district09/php_package_qa-drupal/compare/2.0.1...2.0.2

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -70,6 +70,7 @@ grumphp:
         - web/*/contrib
         - web/modules/custom/*/tests
         - web/sites
+        - web/themes/custom/*/source
         - "*.api.php"
         - "*Test.php"
         - "*TestBase.php"


### PR DESCRIPTION
We don't care what is inside the node_modules directory.

Some node modules can have php files in them for whatever reason. We should not check the code within the node_modules directory as it is not ours.