### PR TITLE
Fix phpunit not finding file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [4.0.0-alpha3]
+
+### Changes
+
+- Update the phpunit config file to make them work with the changes done to
+`core/tests/bootstrap.php` in Drupal 11.1.
+
 ## [4.0.0-alpha2]
 
 ### Updated
@@ -444,6 +451,7 @@ Initial setup of the qa-drupal package:
 - Default config files and checks for a Drupal site.
 - Default config files and checks for a Drupal module.
 
+[4.0.0-alpha3]: https://github.com/district09/php_package_qa-drupal/compare/4.0.0-alpha2...4.0.0-alpha3
 [4.0.0-alpha2]: https://github.com/district09/php_package_qa-drupal/compare/4.0.0-alpha1...4.0.0-alpha2
 [4.0.0-alpha1]: https://github.com/district09/php_package_qa-drupal/compare/3.0.2...4.0.0-alpha1
 [3.0.2]: https://github.com/district09/php_package_qa-drupal/compare/3.0.1...3.0.2

--- a/configs/phpunit-site.xml
+++ b/configs/phpunit-site.xml
@@ -16,16 +16,16 @@
 
   <testsuites>
     <testsuite name="unit">
-      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/UnitTestSuite.php</file>
+      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/UnitTestSuite.php</file>
     </testsuite>
     <testsuite name="kernel">
-      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/KernelTestSuite.php</file>
+      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/KernelTestSuite.php</file>
     </testsuite>
     <testsuite name="functional">
-      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalTestSuite.php</file>
+      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalTestSuite.php</file>
     </testsuite>
     <testsuite name="functional-javascript">
-      <file>../vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalJavascriptTestSuite.php</file>
+      <file>vendor/digipolisgent/qa-drupal/src/PHPUnit/TestSuites/FunctionalJavascriptTestSuite.php</file>
     </testsuite>
   </testsuites>
 
@@ -38,9 +38,9 @@
 
   <coverage>
     <include>
-      <directory suffix=".php">modules/custom</directory>
-      <directory suffix=".php">profiles/custom</directory>
-      <directory suffix=".php">themes/custom</directory>
+      <directory suffix=".php">web/modules/custom</directory>
+      <directory suffix=".php">web/profiles/custom</directory>
+      <directory suffix=".php">web/themes/custom</directory>
     </include>
     <exclude>
         <directory suffix=".api.php">./</directory>
@@ -49,7 +49,7 @@
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
         <directory suffix="TestCase.php">./</directory>
-        <directory>themes/custom/*/source</directory>
+        <directory>web/themes/custom/*/source</directory>
     </exclude>
 
     <report>


### PR DESCRIPTION
A line was removed from the Drupal's phpunit boostrap file, causing the old config to break:
https://git.drupalcode.org/project/drupal/-/blob/10.2.0/core/tests/bootstrap.php#L185