### PR TITLE
Add twigcs because this was removed for the D11 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "drupal/drupal-extension": "^5.0",
         "enlightn/security-checker": "^2.0",
         "ergebnis/composer-normalize": "^2.11",
+        "friendsoftwig/twigcs": "^6.5",
         "mglaman/phpstan-drupal": "^1.1",
         "nette/neon": "^3.2",
         "phpcompatibility/php-compatibility": "^9.3",

--- a/src/Twigcs/Ruleset/Twig.php
+++ b/src/Twigcs/Ruleset/Twig.php
@@ -4,7 +4,6 @@ namespace Digipolisgent\QA\Drupal\Twigcs\Ruleset;
 
 use FriendsOfTwig\Twigcs\Ruleset\Official;
 use FriendsOfTwig\Twigcs\Ruleset\RulesetInterface;
-use NdB\TwigCSA11Y\Ruleset;
 
 /**
  * Twig ruleset.
@@ -26,8 +25,7 @@ class Twig implements RulesetInterface
     public function getRules()
     {
         $official = new Official($this->twigMajorVersion);
-        $wcag = new Ruleset($this->twigMajorVersion);
 
-        return array_merge($official->getRules(), $wcag->getRules());
+        return array_merge($official->getRules());
     }
 }


### PR DESCRIPTION
Since the old twigcs-a11y module is not symfony 7 proof and no longer maintained it's better to just use freiendsoftwig/twigcs.

Also see:
https://github.com/district09/php_package_qa-drupal/issues/42