### PR TITLE
Update PhpUnit configuration

### DIFF
--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -6,8 +6,13 @@
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         cacheDirectory=".phpunit.cache"
+         cacheDirectory=".phpunit.result.cache"
 >
   <php>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
@@ -47,7 +52,8 @@
 
   <source>
     <include>
-      <directory suffix=".php">./</directory>
+      <directory suffix=".php">./src</directory>
+      <directory suffix=".php">./modules/**/src</directory>
     </include>
     <exclude>
       <directory suffix=".api.php">./</directory>
@@ -56,7 +62,6 @@
       <directory suffix="Test.php">./</directory>
       <directory suffix="TestBase.php">./</directory>
       <directory suffix="TestCase.php">./</directory>
-      <directory>web/themes/custom/*/source</directory>
     </exclude>
   </source>
 </phpunit>

--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
-<phpunit bootstrap="vendor/digipolisgent/qa-drupal/src/PHPUnit/Extension/bootstrap.php"
-         printerClass="Drupal\Tests\Listeners\HtmlOutputPrinter"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/digipolisgent/qa-drupal/src/PHPUnit/Extension/bootstrap.php"
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true">
-
+         beStrictAboutChangesToGlobalState="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+>
   <php>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>
   </php>
@@ -37,31 +38,25 @@
     </testsuite>
   </testsuites>
 
-  <listeners>
-    <listener class="Drupal\Tests\Listeners\DrupalListener">
-    </listener>
-    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
-    </listener>
-  </listeners>
-
   <coverage>
-    <include>
-      <directory suffix=".php">./</directory>
-    </include>
-    <exclude>
-        <directory>./vendor</directory>
-        <directory suffix=".api.php">./</directory>
-        <directory suffix="Spy.php">./</directory>
-        <directory suffix="Stub.php">./</directory>
-        <directory suffix="Test.php">./</directory>
-        <directory suffix="TestBase.php">./</directory>
-        <directory suffix="TestCase.php">./</directory>
-        <directory>web/themes/custom/*/source</directory>
-    </exclude>
-
     <report>
       <html outputDirectory="../build/coverage"/>
       <clover outputFile="../build/logs/clover.xml"/>
     </report>
   </coverage>
+
+  <source>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+    <exclude>
+      <directory suffix=".api.php">./</directory>
+      <directory suffix="Spy.php">./</directory>
+      <directory suffix="Stub.php">./</directory>
+      <directory suffix="Test.php">./</directory>
+      <directory suffix="TestBase.php">./</directory>
+      <directory suffix="TestCase.php">./</directory>
+      <directory>web/themes/custom/*/source</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -45,8 +45,8 @@
 
   <coverage>
     <report>
-      <html outputDirectory="../build/coverage"/>
-      <clover outputFile="../build/logs/clover.xml"/>
+      <html outputDirectory="./build/coverage"/>
+      <clover outputFile="./build/logs/clover.xml"/>
     </report>
   </coverage>
 

--- a/configs/phpunit-site.xml
+++ b/configs/phpunit-site.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="web/core/tests/bootstrap.php" colors="true"
+         bootstrap="web/core/tests/bootstrap.php"
+         colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         cacheDirectory=".phpunit.cache"
+         cacheDirectory=".phpunit.result.cache"
 >
   <php>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>

--- a/configs/phpunit-site.xml
+++ b/configs/phpunit-site.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
-<phpunit bootstrap="web/core/tests/bootstrap.php"
-         printerClass="Drupal\Tests\Listeners\HtmlOutputPrinter"
-         colors="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="web/core/tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true">
-
+         beStrictAboutChangesToGlobalState="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+>
   <php>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>
   </php>
@@ -43,32 +43,27 @@
     </testsuite>
   </testsuites>
 
-  <listeners>
-    <listener class="Drupal\Tests\Listeners\DrupalListener">
-    </listener>
-    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
-    </listener>
-  </listeners>
-
   <coverage>
+    <report>
+      <html outputDirectory="../build/coverage"/>
+      <clover outputFile="../build/logs/clover.xml"/>
+    </report>
+  </coverage>
+
+  <source>
     <include>
       <directory suffix=".php">web/modules/custom</directory>
       <directory suffix=".php">web/profiles/custom</directory>
       <directory suffix=".php">web/themes/custom</directory>
     </include>
     <exclude>
-        <directory suffix=".api.php">./</directory>
-        <directory suffix="Spy.php">./</directory>
-        <directory suffix="Stub.php">./</directory>
-        <directory suffix="Test.php">./</directory>
-        <directory suffix="TestBase.php">./</directory>
-        <directory suffix="TestCase.php">./</directory>
-        <directory>web/themes/custom/*/source</directory>
+      <directory suffix=".api.php">./</directory>
+      <directory suffix="Spy.php">./</directory>
+      <directory suffix="Stub.php">./</directory>
+      <directory suffix="Test.php">./</directory>
+      <directory suffix="TestBase.php">./</directory>
+      <directory suffix="TestCase.php">./</directory>
+      <directory>web/themes/custom/*/source</directory>
     </exclude>
-
-    <report>
-      <html outputDirectory="../build/coverage"/>
-      <clover outputFile="../build/logs/clover.xml"/>
-    </report>
-  </coverage>
+  </source>
 </phpunit>


### PR DESCRIPTION
Update the PHPUnit configuration files to:

- Support version 10 & 11.
- Fix deprecations.
- Add more verbose output on test errors/warnings/notices.