### PR TITLE
Add support for module collections

### DIFF
--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -23,22 +23,27 @@
   <testsuites>
     <testsuite name="unit">
       <directory>tests/src/Unit*</directory>
+      <directory>**/tests/src/Unit</directory>
       <directory>modules/**/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
       <directory>tests/src/Kernel*</directory>
+      <directory>**/tests/src/Kernel</directory>
       <directory>modules/**/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>tests/src/Functional*</directory>
+      <directory>**/tests/src/Functional</directory>
       <directory>modules/**/tests/src/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>tests/src/FunctionalJavascript*</directory>
+      <directory>**/tests/src/FunctionalJavascript</directory>
       <directory>modules/**/tests/src/FunctionalJavascript</directory>
     </testsuite>
     <testsuite name="build">
       <directory>tests/src/Build*</directory>
+      <directory>**/tests/src/Build</directory>
       <directory>modules/**/tests/src/Build</directory>
     </testsuite>
   </testsuites>
@@ -53,6 +58,7 @@
   <source>
     <include>
       <directory suffix=".php">./src</directory>
+      <directory suffix=".php">./**/src</directory>
       <directory suffix=".php">./modules/**/src</directory>
     </include>
     <exclude>


### PR DESCRIPTION
Some modules are a folder containing multiple submodules who are not grouped in a `modules` directory. Those locations are added to the PHPUnit configuration.